### PR TITLE
Add gh reusable actions to generate dynamic runners for windows/linux

### DIFF
--- a/.github/workflows/provision-runner.yml
+++ b/.github/workflows/provision-runner.yml
@@ -1,0 +1,81 @@
+name: Provision EC2 VM
+
+on:
+  workflow_call:
+    inputs:
+      ec2-image-id:
+        description: 'The AMI ID for the EC2 instance'
+        required: true
+        type: string
+      ec2-os-type:
+        description: 'The os type of the ec2 instance (windows/linux)'
+        required: true
+        type: string
+      ec2-instance-type:
+        description: 'The instance type for the EC2 instance'
+        required: true
+        type: string
+      aws-region:
+        description: 'AWS Region'
+        required: false
+        type: string
+        default: us-east-1
+      security-group-id:
+        description: 'Security group for the EC2 instance'
+        required: true
+        type: string
+      subnet-id:
+        description: 'Subnet ID for the EC2 instance'
+        required: true
+        type: string
+    secrets:
+      aws-access-key-id:
+        description: 'AWS Access Key ID'
+        required: true
+      aws-secret-access-key:
+        description: 'AWS Secret Access Key'
+        required: true
+      github-token:
+        description: 'Personal Access Token For GH'
+        required: true
+    outputs:
+      instance_label: 
+        description: "The label of the VM that was created."
+        value: ${{ jobs.provision-ec2.outputs.label }}
+      ec2-instance-id: 
+        description: "Instance id of the VM that was created."
+        value: ${{ jobs.provision-ec2.outputs.instance_id }}
+
+jobs:
+  provision-ec2:
+    runs-on: ubuntu-latest
+    outputs:
+      instance_id: ${{ steps.ec2.outputs.ec2-instance-id }}
+      label: ${{ steps.ec2.outputs.label }}
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.aws-access-key-id }}
+          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          aws-region: ${{ inputs.aws-region }}  # Default is us-east-1
+
+      - name: Start EC2 GitHub runner
+        id: ec2
+        uses: crunchy234/ec2-github-runner@main
+        with:
+          mode: start
+          github-token: ${{ secrets.github-token }}
+          ec2-os: ${{ inputs.ec2-os-type }}
+          ec2-instance-type: ${{ inputs.ec2-instance-type }}        
+          ec2-image-id: ${{ inputs.ec2-image-id }}
+          subnet-id: ${{ inputs.subnet-id }}
+          security-group-id: ${{ inputs.security-group-id }}
+
+      - name: Output EC2 Instance ID
+        run: |
+          echo "EC2 Instance ID: ${{ steps.ec2.outputs.ec2-instance-id }}"
+          echo "Label : ${{ steps.ec2.outputs.label }}"

--- a/.github/workflows/remove-runner.yml
+++ b/.github/workflows/remove-runner.yml
@@ -1,0 +1,63 @@
+name: Delete EC2 VM
+
+on:
+  workflow_call:
+    inputs:
+      ec2-instance-id:
+        description: 'The instance ID for the EC2 instance'
+        required: true
+        type: string
+      ec2-runner-label:
+        description: 'The instance ID for the EC2 instance'
+        required: true
+        type: string
+      aws-region:
+        description: 'AWS Region'
+        required: false
+        type: string
+        default: us-east-1
+    secrets:
+      aws-access-key-id:
+        description: 'AWS Access Key ID'
+        required: true
+      aws-secret-access-key:
+        description: 'AWS Secret Access Key'
+        required: true
+      github-token:
+        description: 'Personal Access Token For GH'
+        required: true
+
+jobs:
+  delete-ec2:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      # Configure AWS credentials using the aws-actions/configure-aws-credentials action
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.aws-access-key-id }}
+          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          aws-region: ${{ inputs.aws-region }}  # Specify your preferred region
+      
+      - name: Output EC2 Instance ID
+        run: |
+          echo "EC2 Instance"
+          echo ${{ inputs.ec2-instance-id }}
+          echo ${{ inputs.ec2-runner-label }}
+
+      # Start the EC2 GitHub runner
+      - name: Terminate EC2 GitHub runner
+        uses: crunchy234/ec2-github-runner@main
+        with:
+          mode: stop
+          github-token: ${{ secrets.github-token }}
+          ec2-instance-id: ${{ inputs.ec2-instance-id }}        
+          label: ${{ inputs.ec2-runner-label }}
+
+      - name: Output EC2 Instance ID
+        run: |
+          echo "EC2 Instance Deleted"
+          


### PR DESCRIPTION
This PR contains reusable gh actions to provision and deprovision runners on aws which can be used in the workflows.