### PR TITLE
:seedling:  Increase windows timeout

### DIFF
--- a/.github/workflows/windows-nightly-ci.yml
+++ b/.github/workflows/windows-nightly-ci.yml
@@ -81,6 +81,7 @@ jobs:
         EC2_PASSWORD: ${{ secrets.NONADMIN_PASSWORD }}
 
     - name: Fetch artifacts
+      if: ${{ !cancelled() }}
       run: |
         sshpass -p ${EC2_PASSWORD} scp -o StrictHostKeyChecking=no -r ${EC2_USER}@${{ needs.start-ec2-instance.outputs.ec2-host }}:C:/Users/nonadmin/AppData/Roaming/Code/logs ./vscode-logs
         sshpass -p ${EC2_PASSWORD} scp -o StrictHostKeyChecking=no -r ${EC2_USER}@${{ needs.start-ec2-instance.outputs.ec2-host }}:C:/Users/nonadmin/kai-ci/screenshots ./screenshots

--- a/e2e/tests/vscode.test.ts
+++ b/e2e/tests/vscode.test.ts
@@ -22,6 +22,7 @@ test.describe('VSCode Tests', () => {
       exact: true,
     });
     await expect(heading).toBeVisible();
+    await vscodeApp.getWindow().waitForTimeout(10000);
     await window.screenshot({
       path: './screenshots/kai-installed-screenshot.png',
     });


### PR DESCRIPTION
Increase timeouts for Windows and ensure that the artifacts get uploaded even if the tests fail.