### PR TITLE
:sparkles: Automate resolution with low effort

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,8 @@
 # Instead, copy it, remove the .example extension and provide your custom values
 # For git password please use your generated git token, not a clear text password
 
-VSIX_FILE_NAME='konveyor-v0.0.13.vsix'
-DEFAULT_VSIX_DOWNLOAD_URL= 'https://github.com/konveyor/editor-extensions/releases/download/v0.0.13/konveyor-v0.0.13.vsix'
+VSIX_FILE_NAME='konveyor-v0.1.0.vsix'
+DEFAULT_VSIX_DOWNLOAD_URL= 'https://github.com/konveyor/editor-extensions/releases/download/v0.1.0/konveyor-v0.1.0.vsix'
 
 # For Windows Path needs to be given in below format
 WINDOWS_VSCODE_EXECUTABLE_PATH='C:\Users\nonadmin\AppData\Local\Programs\Microsoft VS Code\Code.exe'

--- a/.github/workflows/linux-nightly-ci.yml
+++ b/.github/workflows/linux-nightly-ci.yml
@@ -75,11 +75,11 @@ jobs:
       run: npx playwright test --reporter=list
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-    - name: Upload screenshots
+    - name: Upload test artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: vscode-screenshots
-        path: screenshots
+        name: tests-output
+        path: ./tests-output
       if: ${{ !cancelled() }}
     - name: Upload kai logs
       uses: actions/upload-artifact@v4

--- a/.github/workflows/windows-nightly-ci.yml
+++ b/.github/workflows/windows-nightly-ci.yml
@@ -61,7 +61,8 @@ jobs:
         echo "cd C:\\Users\\nonadmin\\kai-ci" >> execute-tests.bat
         echo powershell -Command "\"npm install\"" >> execute-tests.bat        
         echo "copy .env.example .env" >> execute-tests.bat
-        echo "echo OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" >> .env" >> execute-tests.bat
+        echo "echo OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" >> .env" >> execute-tests.bat 
+        echo "echo CI=true >> .env" >> execute-tests.bat 
         echo "npx playwright test" >> execute-tests.bat
         echo "EXIT /B %ERRORLEVEL%" >> execute-tests.bat
       shell: bash

--- a/e2e/pages/vscode.pages.ts
+++ b/e2e/pages/vscode.pages.ts
@@ -165,6 +165,7 @@ export class VSCode {
 
     await expect(input).toBeVisible({ timeout: 5000 });
     await input.fill(`>${command}`);
+    await expect(this.window.locator('a.label-name span.highlight', { hasText: command })).toBeVisible();
 
     await input.press('Enter');
     await this.window.waitForTimeout(1000);
@@ -173,26 +174,26 @@ export class VSCode {
   public async selectSourcesAndTargets(sources: string[], targets: string[]) {
     const window = this.window;
     await this.executeQuickCommand('sources and targets');
-    await window.waitForTimeout(500); // this was 5000
+    await this.waitDefault();
     await window.screenshot({
       path: `${VSCode.SCREENSHOTS_FOLDER}/debug-target.png`,
     });
     const targetInput = window.getByPlaceholder('Choose one or more target');
-    await window.waitForTimeout(500); // this was 5000
+    await this.waitDefault();
     await expect(targetInput).toBeVisible();
     for (const target of targets) {
       await targetInput.fill(target);
-      await window.waitForTimeout(500); // this was 5000
+      await this.waitDefault();
       await window
         .getByRole('checkbox', { name: `${target}` })
         .nth(1)
         .click();
-      await window.waitForTimeout(500); // this was 5000
+      await this.waitDefault();
     }
 
-    await window.waitForTimeout(500); // this was 5000
+    await this.waitDefault();
     await targetInput.press('Enter');
-    await window.waitForTimeout(500); // this was 5000
+    await this.waitDefault();
 
     const sourceInput = window.getByPlaceholder('Choose one or more source');
     await expect(sourceInput).toBeVisible();
@@ -207,7 +208,7 @@ export class VSCode {
     }
 
     await sourceInput.press('Enter');
-    await window.waitForTimeout(500); // this was 5000
+    await this.waitDefault();
     await window.keyboard.press('Enter');
   }
 
@@ -220,7 +221,7 @@ export class VSCode {
     await this.executeQuickCommand('welcome: open walkthrough');
 
     await window.keyboard.type('set up konveyor');
-    await window.waitForTimeout(500); // this was 5000
+    await this.waitDefault();
     await window.keyboard.press('Enter');
   }
 
@@ -297,5 +298,13 @@ export class VSCode {
       clipboard.writeText(content);
     }, content);
     await this.window.keyboard.press('Control+v');
+  }
+
+  /**
+   * Even with Playwright default waiting for actionability, in Electron,
+   * Playwright tries to perform some actions before the elements are ready to handle those actions
+   */
+  public async waitDefault() {
+    await this.window.waitForTimeout(process.env.CI ? 50000 : 500);
   }
 }

--- a/e2e/pages/vscode.pages.ts
+++ b/e2e/pages/vscode.pages.ts
@@ -248,6 +248,7 @@ export class VSCode {
   public async startServer(): Promise<void> {
     await this.openAnalysisView();
     const analysisView = await this.getAnalysisIframe();
+    await this.waitDefault();
     if (
       !(await analysisView.getByRole('button', { name: 'Stop' }).isVisible())
     ) {

--- a/e2e/pages/vscode.pages.ts
+++ b/e2e/pages/vscode.pages.ts
@@ -255,6 +255,7 @@ export class VSCode {
       !(await analysisView.getByRole('button', { name: 'Stop' }).isVisible())
     ) {
       await analysisView.getByRole('button', { name: 'Start' }).click();
+      await analysisView.getByRole('button', { name: 'Stop' }).isVisible()
     }
   }
 

--- a/e2e/pages/vscode.pages.ts
+++ b/e2e/pages/vscode.pages.ts
@@ -255,8 +255,27 @@ export class VSCode {
       !(await analysisView.getByRole('button', { name: 'Stop' }).isVisible())
     ) {
       await analysisView.getByRole('button', { name: 'Start' }).click();
-      await analysisView.getByRole('button', { name: 'Stop' }).isVisible()
+      await analysisView.getByRole('button', { name: 'Stop' }).isVisible();
     }
+  }
+
+  public async searchViolation(term: string): Promise<void> {
+    const analysisView = await this.getAnalysisIframe();
+
+    const toggleFilterButton = analysisView.locator(
+      'button[aria-label="Show Filters"]'
+    );
+    const searchInput = analysisView.locator(
+      'input[aria-label="Search violations and incidents"]'
+    );
+    if (await searchInput.isVisible()) {
+      await searchInput.fill(term);
+      return;
+    }
+
+    await toggleFilterButton.click();
+    await searchInput.fill(term);
+    await toggleFilterButton.click();
   }
 
   public async runAnalysis() {

--- a/e2e/pages/vscode.pages.ts
+++ b/e2e/pages/vscode.pages.ts
@@ -170,26 +170,26 @@ export class VSCode {
   public async selectSourcesAndTargets(sources: string[], targets: string[]) {
     const window = this.window;
     await this.executeQuickCommand('sources and targets');
-    await window.waitForTimeout(5000);
+    await window.waitForTimeout(500); // this was 5000
     await window.screenshot({
       path: `${VSCode.SCREENSHOTS_FOLDER}/debug-target.png`,
     });
     const targetInput = window.getByPlaceholder('Choose one or more target');
-    await window.waitForTimeout(5000);
+    await window.waitForTimeout(500); // this was 5000
     await expect(targetInput).toBeVisible();
     for (const target of targets) {
       await targetInput.fill(target);
-      await window.waitForTimeout(5000);
+      await window.waitForTimeout(500); // this was 5000
       await window
         .getByRole('checkbox', { name: `${target}` })
         .nth(1)
         .click();
-      await window.waitForTimeout(5000);
+      await window.waitForTimeout(500); // this was 5000
     }
 
-    await window.waitForTimeout(5000);
+    await window.waitForTimeout(500); // this was 5000
     await targetInput.press('Enter');
-    await window.waitForTimeout(5000);
+    await window.waitForTimeout(500); // this was 5000
 
     const sourceInput = window.getByPlaceholder('Choose one or more source');
     await expect(sourceInput).toBeVisible();
@@ -204,7 +204,7 @@ export class VSCode {
     }
 
     await sourceInput.press('Enter');
-    await window.waitForTimeout(5000);
+    await window.waitForTimeout(500); // this was 5000
     await window.keyboard.press('Enter');
   }
 
@@ -217,21 +217,21 @@ export class VSCode {
     await this.executeQuickCommand('welcome: open walkthrough');
 
     await window.keyboard.type('set up konveyor');
-    await window.waitForTimeout(5000);
+    await window.waitForTimeout(500); // this was 5000
     await window.keyboard.press('Enter');
   }
 
   public async openLeftBarElement(name: LeftBarItems) {
     const window = this.getWindow();
 
-    const navLi = window.locator(`a[aria-label="${name}"]`).locator('..');
+    const navLi = window.locator(`a[aria-label^="${name}"]`).locator('..');
 
     if ((await navLi.getAttribute('aria-expanded')) === 'false') {
       await navLi.click();
     }
   }
 
-  public async runAnalysis() {
+  public async openAnalysisView(): Promise<void> {
     await this.openLeftBarElement(LeftBarItems.Konveyor);
 
     await this.window.getByText('Konveyor Issues').dblclick();
@@ -239,6 +239,16 @@ export class VSCode {
     await this.window
       .locator('a[aria-label="Open Konveyor Analysis View"]')
       .click();
+  }
+
+  public async startServer(): Promise<void> {
+    await this.openAnalysisView();
+    const analysisView = await this.getKonveyorIframe();
+    await analysisView.getByRole('button', { name: 'Start' }).click();
+  }
+
+  public async runAnalysis() {
+    await this.openAnalysisView();
     await this.window.waitForTimeout(15000);
     const analysisView = await this.getKonveyorIframe();
     const runAnalysisBtnLocator = analysisView.getByRole('button', {
@@ -253,7 +263,7 @@ export class VSCode {
    * Returns the iframe that contains the main Konveyor view
    * @return Promise<FrameLocator>
    */
-  private async getKonveyorIframe(): Promise<FrameLocator> {
+  public async getKonveyorIframe(): Promise<FrameLocator> {
     return this.window
       .locator('iframe')
       .first()

--- a/e2e/pages/vscode.pages.ts
+++ b/e2e/pages/vscode.pages.ts
@@ -165,7 +165,9 @@ export class VSCode {
 
     await expect(input).toBeVisible({ timeout: 5000 });
     await input.fill(`>${command}`);
-    await expect(this.window.locator('a.label-name span.highlight', { hasText: command })).toBeVisible();
+    await expect(
+      this.window.locator('a.label-name span.highlight', { hasText: command })
+    ).toBeVisible();
 
     await input.press('Enter');
     await this.window.waitForTimeout(1000);

--- a/e2e/pages/vscode.pages.ts
+++ b/e2e/pages/vscode.pages.ts
@@ -243,14 +243,14 @@ export class VSCode {
 
   public async startServer(): Promise<void> {
     await this.openAnalysisView();
-    const analysisView = await this.getKonveyorIframe();
+    const analysisView = await this.getAnalysisIframe();
     await analysisView.getByRole('button', { name: 'Start' }).click();
   }
 
   public async runAnalysis() {
     await this.openAnalysisView();
     await this.window.waitForTimeout(15000);
-    const analysisView = await this.getKonveyorIframe();
+    const analysisView = await this.getAnalysisIframe();
     const runAnalysisBtnLocator = analysisView.getByRole('button', {
       name: 'Run Analysis',
     });
@@ -263,12 +263,25 @@ export class VSCode {
    * Returns the iframe that contains the main Konveyor view
    * @return Promise<FrameLocator>
    */
-  public async getKonveyorIframe(): Promise<FrameLocator> {
+  public async getAnalysisIframe(): Promise<FrameLocator> {
     return this.window
       .locator('iframe')
       .first()
       .contentFrame()
       .getByTitle('Konveyor Analysis View')
+      .contentFrame();
+  }
+
+  /**
+   * Returns the iframe that contains the main Konveyor view
+   * @return Promise<FrameLocator>
+   */
+  public async getResolutionIframe(): Promise<FrameLocator> {
+    return this.window
+      .locator('iframe')
+      .nth(1)
+      .contentFrame()
+      .getByTitle('Resolution Details')
       .contentFrame();
   }
 

--- a/e2e/pages/vscode.pages.ts
+++ b/e2e/pages/vscode.pages.ts
@@ -305,6 +305,6 @@ export class VSCode {
    * Playwright tries to perform some actions before the elements are ready to handle those actions
    */
   public async waitDefault() {
-    await this.window.waitForTimeout(process.env.CI ? 50000 : 500);
+    await this.window.waitForTimeout(process.env.CI ? 5000 : 500);
   }
 }

--- a/e2e/tests/global.setup.ts
+++ b/e2e/tests/global.setup.ts
@@ -87,11 +87,9 @@ setup.describe(
         .getByRole('button', { name: 'Open Analysis Panel', exact: true })
         .click();
       await vscodeApp.startServer();
-      await vscodeApp
-        .getWindow()
-        .screenshot({
-          path: `${VSCode.SCREENSHOTS_FOLDER}/server-started.png`,
-        });
+      await vscodeApp.getWindow().screenshot({
+        path: `${VSCode.SCREENSHOTS_FOLDER}/server-started.png`,
+      });
     });
   }
 );

--- a/e2e/tests/global.setup.ts
+++ b/e2e/tests/global.setup.ts
@@ -1,0 +1,97 @@
+import { expect, test, test as setup } from '@playwright/test';
+import { LeftBarItems } from '../enums/left-bar-items.enum';
+import { VSCode } from '../pages/vscode.pages';
+
+// TODO : Get repo URL from fixtures
+const repoUrl = 'https://github.com/konveyor-ecosystem/coolstore';
+
+setup.describe(
+  'install extension and configure provider settings',
+  async () => {
+    let vscodeApp: VSCode;
+
+    test.beforeAll(async () => {
+      test.setTimeout(1600000);
+      vscodeApp = await VSCode.init(repoUrl, 'coolstore');
+    });
+
+    test.beforeEach(async () => {
+      // This is for debugging purposes until the Windows tests are stable
+      await vscodeApp.getWindow().screenshot({
+        path: `${VSCode.SCREENSHOTS_FOLDER}/before-${test.info().title.replace(' ', '-')}.png`,
+      });
+    });
+
+    test('Should open Extensions tab and verify installed extension', async () => {
+      const window = vscodeApp.getWindow();
+      await window.waitForTimeout(5000);
+      await vscodeApp.openLeftBarElement(LeftBarItems.Konveyor);
+      const heading = window.getByRole('heading', {
+        name: 'Konveyor',
+        exact: true,
+      });
+      await expect(heading).toBeVisible();
+      await vscodeApp.getWindow().waitForTimeout(10000);
+      await window.screenshot({
+        path: `${VSCode.SCREENSHOTS_FOLDER}/kai-installed-screenshot.png`,
+      });
+    });
+
+    test('Set Sources and targets', async () => {
+      await vscodeApp.getWindow().waitForTimeout(5000);
+      await vscodeApp.selectSourcesAndTargets(
+        [],
+        [
+          'cloud-readiness',
+          'jakarta-ee',
+          'jakarta-ee8',
+          'jakarta-ee9',
+          'quarkus',
+        ]
+      );
+    });
+
+    test('Set Up Konveyor and Start analyzer', async () => {
+      const window = vscodeApp.getWindow();
+      await window.waitForTimeout(5000);
+      await vscodeApp.openSetUpKonveyor();
+      await window.waitForTimeout(5000);
+      await window
+        .getByRole('button', { name: 'Configure Generative AI' })
+        .click();
+      await window.waitForTimeout(5000);
+      await window
+        .getByRole('button', { name: 'Configure GenAI model settings file' })
+        .click();
+      await window.waitForTimeout(5000);
+
+      await window.keyboard.press('Control+a+Delete');
+      await vscodeApp.pasteContent(
+        [
+          'models:',
+          '  OpenAI: &active',
+          '    environment:',
+          `      OPENAI_API_KEY: "${process.env.OPENAI_API_KEY}"`,
+          '    provider: "ChatOpenAI"',
+          '    args:',
+          '      model: "gpt-4o"',
+          'active: *active',
+        ].join('\n')
+      );
+      await window.keyboard.press('Control+s');
+
+      await window.waitForTimeout(5000);
+      await vscodeApp.openSetUpKonveyor();
+      await window.locator('h3.step-title:text("Open Analysis Panel")').click();
+      await window
+        .getByRole('button', { name: 'Open Analysis Panel', exact: true })
+        .click();
+      await vscodeApp.startServer();
+      await vscodeApp
+        .getWindow()
+        .screenshot({
+          path: `${VSCode.SCREENSHOTS_FOLDER}/server-started.png`,
+        });
+    });
+  }
+);

--- a/e2e/tests/vscode.test.ts
+++ b/e2e/tests/vscode.test.ts
@@ -40,10 +40,7 @@ test.describe('VSCode Tests', () => {
     test.setTimeout(3600000);
     await vscodeApp.openAnalysisView();
     const analysisView = await vscodeApp.getAnalysisIframe();
-    const searchInput = analysisView.locator(
-      'input[aria-label="Search violations and incidents"]'
-    );
-    await searchInput.fill('InventoryEntity');
+    await vscodeApp.searchViolation('InventoryEntity');
     await analysisView
       .locator('div.pf-v6-c-card__header-toggle')
       .nth(0)

--- a/e2e/tests/vscode.test.ts
+++ b/e2e/tests/vscode.test.ts
@@ -23,7 +23,10 @@ test.describe('VSCode Tests', () => {
   test('Analyze coolstore app', async () => {
     test.setTimeout(3600000);
     await vscodeApp.runAnalysis();
-
+    await vscodeApp.waitDefault();
+    await vscodeApp.getWindow().screenshot({
+      path: `${VSCode.SCREENSHOTS_FOLDER}/analysis-running.png`,
+    });
     await expect(
       vscodeApp.getWindow().getByText('Analysis completed').first()
     ).toBeVisible({ timeout: 1800000 });

--- a/e2e/tests/vscode.test.ts
+++ b/e2e/tests/vscode.test.ts
@@ -49,7 +49,7 @@ test.describe('VSCode Tests', () => {
     const resolutionView = await vscodeApp.getResolutionIframe();
     const fixLocator = resolutionView.locator('button[aria-label="Apply fix"]').first();
     await expect(fixLocator).toBeVisible({ timeout: 60000 });
-    await fixLocator.click();
+    await fixLocator.click({ force: true });
   });
 
   test.afterEach(async () => {

--- a/e2e/tests/vscode.test.ts
+++ b/e2e/tests/vscode.test.ts
@@ -36,7 +36,7 @@ test.describe('VSCode Tests', () => {
     });
   });
 
-  test('Fix Issue with default effort', async () => {
+  test('Fix Issue with default (Low) effort', async () => {
     test.setTimeout(3600000);
     await vscodeApp.openAnalysisView();
     const analysisView = await vscodeApp.getAnalysisIframe();

--- a/e2e/tests/vscode.test.ts
+++ b/e2e/tests/vscode.test.ts
@@ -33,9 +33,8 @@ test.describe('VSCode Tests', () => {
     });
   });
 
-  test('Fix Issue with low effort', async () => {
+  test('Fix Issue with default effort', async () => {
     test.setTimeout(3600000);
-    const window = vscodeApp.getWindow();
     await vscodeApp.openAnalysisView();
     const analysisView = await vscodeApp.getAnalysisIframe();
     const searchInput = analysisView.locator(
@@ -48,8 +47,9 @@ test.describe('VSCode Tests', () => {
       .click();
     await analysisView.locator('button#get-solution-button').nth(3).click();
     const resolutionView = await vscodeApp.getResolutionIframe();
-    await resolutionView.locator('button[aria-label="Apply fix"]').click();
-    await window.waitForTimeout(5000);
+    const fixLocator = resolutionView.locator('button[aria-label="Apply fix"]').first();
+    await expect(fixLocator).toBeVisible({ timeout: 60000 });
+    await fixLocator.click();
   });
 
   test.afterEach(async () => {

--- a/e2e/tests/vscode.test.ts
+++ b/e2e/tests/vscode.test.ts
@@ -71,13 +71,11 @@ test.describe('VSCode Tests', () => {
 
     await window.waitForTimeout(5000);
     await vscodeApp.openSetUpKonveyor();
-    await window.waitForSelector('h3.step-title:has-text("Start Server")');
-    await window.locator('h3.step-title:text("Start Server")').click();
-    await window.waitForSelector('span:text("Start Analyzer")');
+    await window.locator('h3.step-title:text("Open Analysis Panel")').click();
     await window
-      .getByRole('button', { name: 'Start Analyzer', exact: true })
+      .getByRole('button', { name: 'Open Analysis Panel', exact: true })
       .click();
-    await window.waitForTimeout(5000);
+    await vscodeApp.startServer();
     await vscodeApp
       .getWindow()
       .screenshot({ path: `${VSCode.SCREENSHOTS_FOLDER}/server-started.png` });
@@ -86,6 +84,22 @@ test.describe('VSCode Tests', () => {
   test('Analyze coolstore app', async () => {
     test.setTimeout(3600000);
     await vscodeApp.runAnalysis();
+    await expect(
+      vscodeApp.getWindow().getByText('Analysis completed').first()
+    ).toBeVisible({ timeout: 1800000 });
+    await vscodeApp.getWindow().screenshot({
+      path: `${VSCode.SCREENSHOTS_FOLDER}/analysis-finished.png`,
+    });
+  });
+
+  test('Fix Issue with low effort', async () => {
+    test.setTimeout(3600000);
+    const window = vscodeApp.getWindow();
+    await vscodeApp.openAnalysisView();
+    const analysisView = await vscodeApp.getKonveyorIframe();
+    const searchInput = analysisView.locator('input[aria-label="Search violations and incidents"]');
+
+
     await expect(
       vscodeApp.getWindow().getByText('Analysis completed').first()
     ).toBeVisible({ timeout: 1800000 });

--- a/e2e/tests/vscode.test.ts
+++ b/e2e/tests/vscode.test.ts
@@ -37,7 +37,10 @@ test.describe('VSCode Tests', () => {
 
   test('Set Sources and targets', async () => {
     await vscodeApp.getWindow().waitForTimeout(5000);
-    await vscodeApp.selectSourcesAndTargets([], ['quarkus']);
+    await vscodeApp.selectSourcesAndTargets(
+      [],
+      ['cloud-readiness', 'jakarta-ee', 'jakarta-ee8', 'jakarta-ee9', 'quarkus']
+    );
   });
 
   test('Set Up Konveyor and Start analyzer', async () => {
@@ -96,16 +99,19 @@ test.describe('VSCode Tests', () => {
     test.setTimeout(3600000);
     const window = vscodeApp.getWindow();
     await vscodeApp.openAnalysisView();
-    const analysisView = await vscodeApp.getKonveyorIframe();
-    const searchInput = analysisView.locator('input[aria-label="Search violations and incidents"]');
-
-
-    await expect(
-      vscodeApp.getWindow().getByText('Analysis completed').first()
-    ).toBeVisible({ timeout: 1800000 });
-    await vscodeApp.getWindow().screenshot({
-      path: `${VSCode.SCREENSHOTS_FOLDER}/analysis-finished.png`,
-    });
+    const analysisView = await vscodeApp.getAnalysisIframe();
+    const searchInput = analysisView.locator(
+      'input[aria-label="Search violations and incidents"]'
+    );
+    await searchInput.fill('InventoryEntity');
+    await analysisView
+      .locator('div.pf-v6-c-card__header-toggle')
+      .nth(0)
+      .click();
+    await analysisView.locator('button#get-solution-button').nth(3).click();
+    const resolutionView = await vscodeApp.getResolutionIframe();
+    await resolutionView.locator('button[aria-label="Apply fix"]').click();
+    await window.waitForTimeout(5000);
   });
 
   test.afterEach(async () => {

--- a/e2e/tests/vscode.test.ts
+++ b/e2e/tests/vscode.test.ts
@@ -1,16 +1,16 @@
 import { test, expect } from '@playwright/test';
 import { VSCode } from '../pages/vscode.pages';
-import { LeftBarItems } from '../enums/left-bar-items.enum';
 
-// TODO : Get repo URL from fixtures
-const repoUrl = 'https://github.com/konveyor-ecosystem/coolstore';
+// TODO (abrugaro) : Get from data
+const projectFolder = 'coolstore';
 
 test.describe('VSCode Tests', () => {
   let vscodeApp: VSCode;
 
   test.beforeAll(async () => {
     test.setTimeout(1600000);
-    vscodeApp = await VSCode.init(repoUrl, 'coolstore');
+    vscodeApp = await VSCode.open(projectFolder);
+    await vscodeApp.startServer();
   });
 
   test.beforeEach(async () => {
@@ -20,76 +20,14 @@ test.describe('VSCode Tests', () => {
     });
   });
 
-  test('Should open Extensions tab and verify installed extension', async () => {
-    const window = vscodeApp.getWindow();
-    await window.waitForTimeout(5000);
-    await vscodeApp.openLeftBarElement(LeftBarItems.Konveyor);
-    const heading = window.getByRole('heading', {
-      name: 'Konveyor',
-      exact: true,
-    });
-    await expect(heading).toBeVisible();
-    await vscodeApp.getWindow().waitForTimeout(10000);
-    await window.screenshot({
-      path: `${VSCode.SCREENSHOTS_FOLDER}/kai-installed-screenshot.png`,
-    });
-  });
-
-  test('Set Sources and targets', async () => {
-    await vscodeApp.getWindow().waitForTimeout(5000);
-    await vscodeApp.selectSourcesAndTargets(
-      [],
-      ['cloud-readiness', 'jakarta-ee', 'jakarta-ee8', 'jakarta-ee9', 'quarkus']
-    );
-  });
-
-  test('Set Up Konveyor and Start analyzer', async () => {
-    const window = vscodeApp.getWindow();
-    await window.waitForTimeout(5000);
-    await vscodeApp.openSetUpKonveyor();
-    await window.waitForTimeout(5000);
-    await window
-      .getByRole('button', { name: 'Configure Generative AI' })
-      .click();
-    await window.waitForTimeout(5000);
-    await window
-      .getByRole('button', { name: 'Configure GenAI model settings file' })
-      .click();
-    await window.waitForTimeout(5000);
-
-    await window.keyboard.press('Control+a+Delete');
-    await vscodeApp.pasteContent(
-      [
-        'models:',
-        '  OpenAI: &active',
-        '    environment:',
-        `      OPENAI_API_KEY: "${process.env.OPENAI_API_KEY}"`,
-        '    provider: "ChatOpenAI"',
-        '    args:',
-        '      model: "gpt-4o"',
-        'active: *active',
-      ].join('\n')
-    );
-    await window.keyboard.press('Control+s');
-
-    await window.waitForTimeout(5000);
-    await vscodeApp.openSetUpKonveyor();
-    await window.locator('h3.step-title:text("Open Analysis Panel")').click();
-    await window
-      .getByRole('button', { name: 'Open Analysis Panel', exact: true })
-      .click();
-    await vscodeApp.startServer();
-    await vscodeApp
-      .getWindow()
-      .screenshot({ path: `${VSCode.SCREENSHOTS_FOLDER}/server-started.png` });
-  });
-
   test('Analyze coolstore app', async () => {
     test.setTimeout(3600000);
     await vscodeApp.runAnalysis();
+
     await expect(
       vscodeApp.getWindow().getByText('Analysis completed').first()
     ).toBeVisible({ timeout: 1800000 });
+
     await vscodeApp.getWindow().screenshot({
       path: `${VSCode.SCREENSHOTS_FOLDER}/analysis-finished.png`,
     });

--- a/e2e/tests/vscode.test.ts
+++ b/e2e/tests/vscode.test.ts
@@ -47,7 +47,9 @@ test.describe('VSCode Tests', () => {
       .click();
     await analysisView.locator('button#get-solution-button').nth(3).click();
     const resolutionView = await vscodeApp.getResolutionIframe();
-    const fixLocator = resolutionView.locator('button[aria-label="Apply fix"]').first();
+    const fixLocator = resolutionView
+      .locator('button[aria-label="Apply fix"]')
+      .first();
     await expect(fixLocator).toBeVisible({ timeout: 60000 });
     await fixLocator.click({ force: true });
   });

--- a/e2e/utilities/utils.ts
+++ b/e2e/utilities/utils.ts
@@ -1,10 +1,8 @@
 import * as os from 'os';
 import * as fs from 'fs';
-import * as util from 'util';
-import { exec, execSync } from 'child_process';
+import { execSync } from 'child_process';
 import * as path from 'path';
 
-const execPromise = util.promisify(exec);
 const repoDir = path.resolve('coolstore');
 
 // Function to get OS information
@@ -51,10 +49,7 @@ export async function uninstallExtension() {
 }
 
 export function getVscodeExecutablePath() {
-  const executablePath =
-    getOSInfo() == 'windows'
-      ? process.env.WINDOWS_VSCODE_EXECUTABLE_PATH
-      : process.env.VSCODE_EXECUTABLE_PATH || '/usr/share/code/code';
-  console.log(`VSCode executable path: ${executablePath}`);
-  return executablePath;
+  return getOSInfo() == 'windows'
+    ? process.env.WINDOWS_VSCODE_EXECUTABLE_PATH
+    : process.env.VSCODE_EXECUTABLE_PATH || '/usr/share/code/code';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "yauzl": "^2.10.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.48.0",
+        "@playwright/test": "^1.51.1",
         "@types/node": "^22.7.5",
         "electron": "^32.2.0",
         "playwright-electron": "^0.5.0",
@@ -128,12 +128,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.1.tgz",
-      "integrity": "sha512-s9RtWoxkOLmRJdw3oFvhFbs9OJS0BzrLUc8Hf6l2UdCNd1rqeEyD4BhCJkvzeEoD1FsK4mirsWwGerhVmYKtZg==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
+      "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.48.1"
+        "playwright": "1.51.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -992,11 +993,12 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "node_modules/playwright": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.1.tgz",
-      "integrity": "sha512-j8CiHW/V6HxmbntOfyB4+T/uk08tBy6ph0MpBXwuoofkSnLmlfdYNNkFTYD6ofzzlSqLA1fwH4vwvVFvJgLN0w==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
+      "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.48.1"
+        "playwright-core": "1.51.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1009,9 +1011,10 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.1.tgz",
-      "integrity": "sha512-Yw/t4VAFX/bBr1OzwCuOMZkY1Cnb4z/doAFSwf4huqAGWmf9eMNjmK7NiOljCdLmxeRYcGPPmcDgU0zOlzP0YA==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
+      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@playwright/test": "^1.48.0",
+    "@playwright/test": "^1.51.1",
     "@types/node": "^22.7.5",
     "electron": "^32.2.0",
     "playwright-electron": "^0.5.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
   workers: process.env.CI ? 2 : undefined,
   timeout: 120000,
   reporter: 'line',
+  expect: {
+    timeout: 10000,
+  },
   use: {
     screenshot: 'only-on-failure', // Not yet supported on Electron
     trace: 'retain-on-failure',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,8 +16,12 @@ export default defineConfig({
     timeout: 10000,
   },
   use: {
+    viewport: { width: 1920, height: 1080 },
     screenshot: 'only-on-failure', // Not yet supported on Electron
     trace: 'retain-on-failure',
+    launchOptions: {
+      args: ['--window-size=1920,1080', '--start-maximized'],
+    },
   },
   projects: [
     {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: 0,
   workers: process.env.CI ? 2 : undefined,
-  timeout: 180000,
+  timeout: 120000,
   reporter: 'line',
   expect: {
     timeout: 10000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: 0,
   workers: process.env.CI ? 2 : undefined,
-  timeout: 120000,
+  timeout: 180000,
   reporter: 'line',
   expect: {
     timeout: 10000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,14 +7,23 @@ dotenv.config({ path: path.resolve(__dirname, '.env') });
 export default defineConfig({
   testDir: './e2e/tests',
   outputDir: 'tests-output',
-  fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: 0,
-  workers: 1,
+  workers: process.env.CI ? 2 : undefined,
   timeout: 120000,
   reporter: 'line',
   use: {
-    screenshot: 'only-on-failure', // Not supported on Electron yet
+    screenshot: 'only-on-failure', // Not yet supported on Electron
     trace: 'retain-on-failure',
   },
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /global\.setup\.ts/,
+    },
+    {
+      name: 'tests',
+      dependencies: ['setup'],
+    },
+  ],
 });


### PR DESCRIPTION
Completes #74 

Moved the plugin instalaltion and extension configuration to a global setup file as stated by the [Playwright docs](https://playwright.dev/docs/test-global-setup-teardown)

I'm thinking about moving the analysis to a different setup file as well and configure the dependencies in the config file as it may be the starting point for multiple tests. That could be done in a different PR and its not on the scope of the issue mentioned above.