### PR TITLE
Update configureGenerativeAI method to use quick command approach

### DIFF
--- a/e2e/pages/vscode.pages.ts
+++ b/e2e/pages/vscode.pages.ts
@@ -289,16 +289,9 @@ export class VSCode extends Application {
   }
 
   public async configureGenerativeAI(config: string = DEFAULT_PROVIDER.config) {
-    await this.openSetUpKonveyor();
-    await this.window
-      .getByRole('button', { name: 'Configure Generative AI' })
-      .click();
-    await this.waitDefault();
-    await this.window
-      .getByRole('button', { name: 'Configure GenAI model settings file' })
-      .click();
-    await this.waitDefault();
-
+    await this.executeQuickCommand(
+      'Konveyor: Open the GenAI model provider configuration file'
+    );
     await this.window.keyboard.press('Control+a+Delete');
     await this.pasteContent(config);
     await this.window.keyboard.press('Control+s');


### PR DESCRIPTION
## Summary
Updated the `configureGenerativeAI` method in `vscode.pages.ts` to adapt to UI changes - the walkthrough window appears to no longer be available.

## Changes
- Replaced the walkthrough-based approach with direct quick command execution
- Removed calls to `openSetUpKonveyor()` and button interactions
- Now uses `Konveyor: Open the GenAI model provider configuration file` quick command

## Before
The method navigated through the walkthrough UI:
1. Open Konveyor setup walkthrough
2. Click "Configure Generative AI" button  
3. Click "Configure GenAI model settings file" button

## After  
Direct approach using VS Code quick commands:
1. Execute quick command to open the GenAI config file directly
2. Same file editing workflow (select all, paste, save)

This change makes the automation more reliable since it doesn't depend on the walkthrough UI being present.