### PR TITLE
Feat/automate delete profile 117

### DIFF
--- a/e2e/pages/vscode.pages.ts
+++ b/e2e/pages/vscode.pages.ts
@@ -266,4 +266,43 @@ export class VSCode extends Application {
     }
     await this.window.keyboard.press('Escape');
   }
+
+  public async deleteProfile(profileNamePrefix?: string) {
+    await this.executeQuickCommand('Konveyor: Manage Analysis Profiles');
+
+    const manageProfileView = await this.getView(KAIViews.manageProfiles);
+    const profileList = manageProfileView.getByRole('list', {
+      name: 'Profile list',
+    });
+    const profileItems = profileList.getByRole('listitem');
+    try {
+      if (profileNamePrefix) {
+        /*
+         * Locate the profile by a prefix match on its name.
+         * A regular expression is used because new profiles often have
+         * an unpredictable random suffix appended to their name,
+         * preventing an exact string match.
+         *
+         * In scenarios where multiple profiles might match the given prefix,
+         * and a unique match cannot be guaranteed, .last() is used to
+         * select the last matching profile as the default action.
+         */
+        const regex = new RegExp('^' + profileNamePrefix);
+        await profileItems.filter({ hasText: regex }).last().click();
+      } else {
+        await profileItems.first().click();
+      }
+
+      await manageProfileView
+        .getByRole('button', { name: 'Delete Profile' })
+        .click();
+      const confirmButton = manageProfileView
+        .getByRole('dialog', { name: 'Delete profile?' })
+        .getByRole('button', { name: 'Confirm' });
+      await confirmButton.waitFor({ state: 'visible' });
+      await confirmButton.click();
+    } catch (error) {
+      console.log('Error deleting profile:', error);
+    }
+  }
 }

--- a/e2e/pages/vscode.pages.ts
+++ b/e2e/pages/vscode.pages.ts
@@ -268,7 +268,7 @@ export class VSCode extends Application {
   }
 
   public async deleteProfile(profileNamePrefix?: string) {
-    await this.executeQuickCommand('Konveyor: Manage Analysis Profiles');
+    await this.executeQuickCommand('Konveyor: Manage Analysis Profile');
 
     const manageProfileView = await this.getView(KAIViews.manageProfiles);
     const profileList = manageProfileView.getByRole('list', {

--- a/e2e/tests/configure-and-run-analysis.test.ts
+++ b/e2e/tests/configure-and-run-analysis.test.ts
@@ -36,6 +36,11 @@ test.describe(`Configure extension and run analysis`, () => {
     ).toBeVisible({ timeout: 300000 });
   });
 
+  test('Delete profile', async () => {
+    await vscodeApp.waitDefault();
+    await vscodeApp.deleteProfile();
+  });
+
   test.afterAll(async () => {
     await vscodeApp.closeVSCode();
   });


### PR DESCRIPTION
This PR introduces a new **deleteProfile** method and integrates it into existing E2E test suites to improve cleanup.

**Key Changes:**

- `deleteProfile` Method: Adds a new asynchronous function to delete analysis profiles by name prefix. It uses regular expressions to handle random suffixes in profile names and defaults to selecting the last matched profile (`.last()`) if multiple exist, or the first (`.first()`) if no prefix is provided.

- Test Cleanup in `analyze_coolstore.test.ts`: The `afterAll` hook now utilizes `deleteProfile` for robust post-test cleanup of analysis profiles, alongside conditional evaluation execution.

- Test Cleanup in `configure-and-run-analysis.test.ts`: A call to `deleteProfile` is added at the end of the test run to ensure proper cleanup of the initial profile created during setup, which was previously left undeleted.
 

Closes konveyor/editor-extensions#624

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete analysis profiles through the user interface.

* **Tests**
  * Introduced a new test case to verify the profile deletion functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->